### PR TITLE
replace broken image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ ARG IMAGE=store/intersystems/irishealth:2019.3.0.308.0-community
 ARG IMAGE=store/intersystems/iris-community:2019.3.0.309.0
 ARG IMAGE=store/intersystems/iris-community:2019.4.0.379.0
 ARG IMAGE=store/intersystems/iris-community:2020.1.0.199.0
-ARG IMAGE=intersystemsdc/iris-community:2019.4.0.383.0-zpm
+# ARG IMAGE=intersystemsdc/iris-community:2019.4.0.383.0-zpm
+ARG IMAGE=intersystemsdc/iris-community:2020.4.0.524.0-zpm
 FROM $IMAGE
 
 USER root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
       context: .
       dockerfile: Dockerfile
     restart: always
-    ports: 
+    ports:
+      - 1972
       - 51773
       - 52773
       - 53773


### PR DESCRIPTION
build 2019.4.0.383.0-zpm seems to exit with **SHELL ["/irissession.sh"]**
this breaks further processing:
~~~
> ERROR: Service 'iris' failed to build : The command 
> '/irissession.sh chown ${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} /opt/irisapp' 
> returned a non-zero code: 1
~~~
added to fix it: 
ARG IMAGE=intersystemsdc/iris-community:**2020.4.0.524.0-zpm**