### PR TITLE
Fix error reporting in checkPivots()

### DIFF
--- a/src/dev/bi.cls
+++ b/src/dev/bi.cls
@@ -96,12 +96,13 @@ ClassMethod checkPivots(stopOnError As %Boolean = 0) As %Status
 		set countOfPivots = countOfPivots + 1
 		set:$$$ISERR(sc) countOfErrors = countOfErrors + 1
 		quit:$$$ISERR(sc)&&stopOnError
-		set key = $order(listOfPivots(key))
 		// sometimes errors is empty 
 		if errors '= ""
 		{
 			set errorList = errorList _ $lb(errors, key)
-		}	
+		}
+		
+		set key = $order(listOfPivots(key))	
 	}
 	// going through list with pivots and errors
 	w !, "Pivot errors and pivots summary"


### PR DESCRIPTION
Currently when checkPivots() loops through pivot tables, it will $order to the next key before printing errors to the terminal. This will falsely attribute any errors reported to the next pivot in the list instead of the correct pivot.

This fixes this issue by moving the $order call to after the error check.

Testing: pulled this change into a local package installation and ran the method to check that it functions correctly.